### PR TITLE
Calculate active playlist duration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1810,9 +1810,9 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winnow"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61de7bac303dc551fe038e2b3cef0f571087a47571ea6e79a87692ac99b99699"
+checksum = "ca0ace3845f0d96209f0375e6d367e3eb87eb65d27d445bdc9f1843a26f39448"
 dependencies = [
  "memchr",
 ]

--- a/src/main.rs
+++ b/src/main.rs
@@ -97,11 +97,36 @@ async fn song(id: String) {
     }
 }
 
+#[get("/now")]
+async fn now_playing() {
+    if let Some(active_playlist) = fetch_playlist().await {
+        println!("{:?}", active_playlist);
+
+        if let Some(all_playlist_songs) = fetch_playlist_songs_by(active_playlist.playlist.id).await
+        {
+            println!("{:?}", all_playlist_songs);
+
+            let total_playlist_duration = all_playlist_songs
+                .iter()
+                .fold(0.0, |acc, song| acc + song.duration);
+
+            println!("{:?}", total_playlist_duration);
+        }
+    }
+}
+
 #[launch]
 fn rocket() -> _ {
     rocket::build().mount(
         "/",
-        routes![index, current_playlist, playlist, song, playlist_songs],
+        routes![
+            index,
+            current_playlist,
+            playlist,
+            song,
+            playlist_songs,
+            now_playing
+        ],
     )
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,12 +100,8 @@ async fn song(id: String) {
 #[get("/now")]
 async fn now_playing() {
     if let Some(active_playlist) = fetch_playlist().await {
-        println!("{:?}", active_playlist);
-
         if let Some(all_playlist_songs) = fetch_playlist_songs_by(active_playlist.playlist.id).await
         {
-            println!("{:?}", all_playlist_songs);
-
             let total_playlist_duration = all_playlist_songs
                 .iter()
                 .fold(0.0, |acc, song| acc + song.duration);


### PR DESCRIPTION
Why:
* We want to have a way of knowing what's the total duration of the
  current active playlist

How:
* Adding a `/now` endpoint that fetches the active playlist and
  sums the duration of each song that belong to it
